### PR TITLE
Pipe DMN to handle large files

### DIFF
--- a/lib/process_pilot/services/decision_evaluator.js
+++ b/lib/process_pilot/services/decision_evaluator.js
@@ -2,13 +2,14 @@
 
 const { decisionTable } = require("@connectedbits/dmn-eval-js")
 const parseCustomFunctions = require("./parse_custom_functions")
+const readInput = require("./read_input")
 
 var args = process.argv.slice(2)
 
 const decisionId = args[0]
-const source = args[1]
-const context = JSON.parse(args[2])
-Object.assign(context, parseCustomFunctions(args.slice(3)))
+const context = JSON.parse(args[1])
+
+Object.assign(context, parseCustomFunctions(args.slice(2)))
 
 const evaluateDecision = async (source) => {
   decisionTable.parseDmnXml(source).then((decisions) => {
@@ -30,5 +31,7 @@ const evaluateDecision = async (source) => {
 }
 
 (async () => {
+  const source = await readInput(process.stdin);
+
   await evaluateDecision(source)
 })();

--- a/lib/process_pilot/services/decision_evaluator.rb
+++ b/lib/process_pilot/services/decision_evaluator.rb
@@ -15,7 +15,7 @@ module ProcessPilot
       end
 
       def call
-        execute_json_process(EVALUATE_BIN, @decision_id, @source, @context.to_json, *@functions, env: @env)
+        execute_json_process(EVALUATE_BIN, @decision_id, @context.to_json, *@functions, stdin: @source, env: @env)
       end
     end
   end

--- a/lib/process_pilot/services/decision_reader.js
+++ b/lib/process_pilot/services/decision_reader.js
@@ -1,12 +1,9 @@
 #!/usr/bin/env node
 
 const DmnModdle = require("dmn-moddle")
+const readInput = require("./read_input")
 
 const dmnModdle = new DmnModdle()
-
-var args = process.argv.slice(2)
-
-const source = args[0]
 
 const parseModdle = async (source) => {
   dmnModdle.fromXML(source, 'dmn:Definitions').then((result) => {
@@ -22,5 +19,6 @@ const parseModdle = async (source) => {
 };
 
 (async () => {
+  const source = await readInput(process.stdin);
   await parseModdle(source);
 })();

--- a/lib/process_pilot/services/decision_reader.rb
+++ b/lib/process_pilot/services/decision_reader.rb
@@ -12,7 +12,7 @@ module ProcessPilot
       end
 
       def call
-        execute_json_process(DECISION_READER_BIN, @source, env: @env)
+        execute_json_process(DECISION_READER_BIN, stdin: @source, env: @env)
       end
     end
   end

--- a/lib/process_pilot/services/process_reader.js
+++ b/lib/process_pilot/services/process_reader.js
@@ -6,9 +6,7 @@ const bpmnModdle = new BpmnModdle({
   zeebe: require("zeebe-bpmn-moddle/resources/zeebe"),
 });
 
-var args = process.argv.slice(2);
-
-const source = args[0];
+const readInput = require("./read_input")
 
 const parseModdle = async (source) => {
   bpmnModdle
@@ -26,5 +24,6 @@ const parseModdle = async (source) => {
 };
 
 (async () => {
+  const source = await readInput(process.stdin);
   await parseModdle(source);
 })();

--- a/lib/process_pilot/services/process_reader.rb
+++ b/lib/process_pilot/services/process_reader.rb
@@ -12,7 +12,7 @@ module ProcessPilot
       end
 
       def call
-        execute_json_process(PROCESS_READER_BIN, @source, env: @env)
+        execute_json_process(PROCESS_READER_BIN, stdin: @source, env: @env)
       end
     end
   end

--- a/lib/process_pilot/services/read_input.js
+++ b/lib/process_pilot/services/read_input.js
@@ -1,0 +1,10 @@
+// Reads an input stream and returns as a utf8 string.
+module.exports = async (input) => {
+  var chunks = [];
+
+  for await (const chunk of input) {
+    chunks.push(chunk);
+  }
+
+  return Buffer.concat(chunks).toString("utf8");
+};

--- a/test/process_pilot/services/process_reader_test.rb
+++ b/test/process_pilot/services/process_reader_test.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+require "test_helper"
+
+module ProcessPilot
+  module Services
+    describe ProcessReader do
+      let(:service) { ProcessReader }
+      let(:source) { fixture_source("kitchen_sink.bpmn") }
+      let(:moddle) { service.call(source) }
+
+      it "should parse bpmn moddle" do
+        _(moddle).wont_be_nil
+        _(moddle.dig("rootElement", "id")).must_equal("Definitions_08enszp")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #26 by piping the DMN to `decision_evaluator.js` instead of using the command line.